### PR TITLE
BLD: Make conda recipe safe to use with different numpy versions.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,18 +7,18 @@ source:
 
 build:
   number: 0
-  string: {{ environ.get('GIT_BUILD_STR', '') }}_py{{ py }}
+  string: {{ environ.get('GIT_BUILD_STR', '') }}_np{{ np }}py{{ py }}
 
 requirements:
   build:
     - setuptools
     - python
-    - numpy
+    - numpy x.x
     - pytest
 
   run:
     - python
-    - numpy
+    - numpy x.x
     - matplotlib
     - tzlocal
     - ipython


### PR DESCRIPTION
As discussed on slack, adding `numpy x.x` makes the built package specific to one minor release of numpy. Without this, `csxtools` can blow up on import if fixed with other packages with C extensions that expected different numpy version.