### PR TITLE
Add ROI option to get_fastccd_images and functions for quickly plotting scans 

### DIFF
--- a/csxtools/image/stack.py
+++ b/csxtools/image/stack.py
@@ -115,7 +115,7 @@ def stackstderr(array):
     return X, Y
 
 
-def ccdmean(images):
+def images_mean(images):
     """Cacluate the mean ccd counts per event
 
     This function calculates the mean of ccd counts for each event. The
@@ -133,7 +133,7 @@ def ccdmean(images):
     return np.array([np.nanmean(stackmean(image)) for image in images])
 
 
-def ccdsum(images):
+def images_sum(images):
     """Cacluate the total ccd counts per event
 
     This function calculates the sum of ccd counts for each event. The
@@ -149,24 +149,3 @@ def ccdsum(images):
     array: 1D numpy array
     """
     return np.array([np.nansum(stackmean(image)) for image in images])
-
-
-def convert_to_3d(images):
-    """Return a 3D array from the "slicerator" object
-
-    Parameters
-    ----------
-    slicerator object : generator returning pims images
-        This is the output of get_fastccd_images
-
-    Returns
-    -------
-    array: 3D numpy array
-    """
-
-    # images = [np.asarray(im) for im in images]
-    ims = images[0]
-    for im in images[1:]:
-        ims = np.vstack((ims, im))
-
-    return ims

--- a/csxtools/image/stack.py
+++ b/csxtools/image/stack.py
@@ -1,3 +1,4 @@
+import numpy as np
 from ..ext import image as extimage
 
 
@@ -112,3 +113,39 @@ def stackstderr(array):
     """
     X, Y = extimage.stackprocess(array, 4)
     return X, Y
+
+
+def ccdmean(images):
+    """Cacluate the mean ccd counts per event
+
+    This function calculates the mean of ccd counts for each event. The
+    input is a "slicerator" object returned by get_fastccd_images.
+
+    Parameters
+    ----------
+    slicerator object : generator returning pims images
+        This is the output of get_fastccd_images
+
+    Returns
+    -------
+    array: 1D numpy array
+    """
+    return np.array([np.nanmean(stackmean(image)) for image in images])
+
+
+def ccdsum(images):
+    """Cacluate the total ccd counts per event
+
+    This function calculates the sum of ccd counts for each event. The
+    input is a "slicerator" object returned by get_fastccd_images.
+
+    Parameters
+    ----------
+    slicerator object : generator returning pims images
+        This is the output of get_fastccd_images
+
+    Returns
+    -------
+    array: 1D numpy array
+    """
+    return np.array([np.nansum(stackmean(image)) for image in images])

--- a/csxtools/image/stack.py
+++ b/csxtools/image/stack.py
@@ -149,3 +149,24 @@ def ccdsum(images):
     array: 1D numpy array
     """
     return np.array([np.nansum(stackmean(image)) for image in images])
+
+
+def convert_to_3d(images):
+    """Return a 3D array from the "slicerator" object
+
+    Parameters
+    ----------
+    slicerator object : generator returning pims images
+        This is the output of get_fastccd_images
+
+    Returns
+    -------
+    array: 3D numpy array
+    """
+
+    # images = [np.asarray(im) for im in images]
+    ims = images[0]
+    for im in images[1:]:
+        ims = np.vstack((ims, im))
+
+    return ims

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -138,6 +138,26 @@ def get_images_to_4D(images, dtype=None):
     return im
 
 
+def get_images_to_3d(images):
+    """Return a 3D array from the "slicerator" object
+
+    Parameters
+    ----------
+    slicerator object : generator returning pims images
+        This is the output of get_fastccd_images
+
+    Returns
+    -------
+    array: 3D numpy array
+    """
+
+    ims = images[0]
+    for im in images[1:]:
+        ims = np.vstack((ims, im))
+
+    return ims
+
+
 @pipeline
 def _correct_fccd_images(image, bgnd, flat, gain):
     return rotate90(correct_images(image, bgnd, flat, gain), 'cw')

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -150,7 +150,7 @@ def _get_images(header, tag, roi=None):
     logger.info("Took %.3f seconds to read data using get_images", t)
 
     if roi is not None:
-        return crop(images, roi)#, rotated=True)
+        return crop(images, roi)
     return images
 
 

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -138,7 +138,7 @@ def get_images_to_4D(images, dtype=None):
     return im
 
 
-def get_images_to_3d(images):
+def get_images_to_3D(images):
     """Return a 3D array from the "slicerator" object
 
     Parameters

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -156,8 +156,8 @@ def _get_images(header, tag, roi=None):
 
 
 @pipeline
-def crop(image, roi=None):#, rotated=False):
-    # if rotated:
+def crop(image, roi=None):
+    # Assuming ROI is specified in the "rotated" (correct) orientation
     roi = [960-roi[3], roi[0], 960-roi[1], roi[2]]
     return image[:,roi[0]:roi[2], roi[1]:roi[3]]
 

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -178,7 +178,7 @@ def _get_images(header, tag, roi=None):
 def crop(image, roi=None):
     # Assuming ROI is specified in the "rotated" (correct) orientation
     roi = [960-roi[3], roi[0], 960-roi[1], roi[2]]
-    return image[:,roi[0]:roi[2], roi[1]:roi[3]]
+    return image[:, roi[0]:roi[2], roi[1]:roi[3]]
 
 
 def crop_flat(image, roi=None):

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import time as ttime
-# from databroker import get_images
-from dataportal import get_images
+from databroker import get_images
 from pims import pipeline
 
 from .fastccd import correct_images


### PR DESCRIPTION
Here is an example notebook showing how the new functions and the ROI parameter can be used.

Picking an ROI before processing images can significantly reduce processing times. 

Also, add a convenience function to get a 3D numpy array from the pims generator returned by get_fastccd_images

https://gist.github.com/vivekthampy/65c4a0c7513a76c34e96