### PR TITLE
FIX: Fix databroker integration for get_fastccd_images.

### DIFF
--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -226,8 +226,7 @@ def get_fastccd_timestamps(header, tag='fccd_image'):
 
     """
     with header.db.reg.handler_context({'AD_HDF5': AreaDetectorHDF5TimestampHandler}):
-        img = [i for i in get_events(header, [tag], fill=True)]
-        timestamps = [i['data'][tag] for i in img if tag in i['data'].keys()]
+        timestamps = list(header.data(tag))
 
     return timestamps
 

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -1,20 +1,18 @@
 import numpy as np
 import time as ttime
-from databroker import get_images, get_events
 from pims import pipeline
 
 from .fastccd import correct_images
 from .image import rotate90, stackmean
 from .settings import detectors
-from filestore.handlers import AreaDetectorHDF5TimestampHandler
+from databroker.assets.handlers import AreaDetectorHDF5TimestampHandler
 
 import logging
 logger = logging.getLogger(__name__)
 
 
 def get_fastccd_images(light_header, dark_headers=None,
-                       flat=None, gain=(1, 4, 8), tag=None, roi=None,
-                       handler_override=None):
+                       flat=None, gain=(1, 4, 8), tag=None, roi=None):
     """Retreive and correct FastCCD Images from associated headers
 
     Retrieve FastCCD Images from databroker and correct for:
@@ -53,10 +51,6 @@ def get_fastccd_images(light_header, dark_headers=None,
         coordinates of the upper-left corner and width and height of
         the ROI: e.g., (x, y, w, h)
 
-    handler_override : class
-        A filestore handler to override the default class used by
-        filestore to get the images
-
     Returns
     -------
         A corrected pims.pipeline of the data
@@ -90,8 +84,7 @@ def get_fastccd_images(light_header, dark_headers=None,
             if d is not None:
                 # Get the images
 
-                bgnd_events = _get_images(d, tag, roi,
-                                          handler_override=handler_override)
+                bgnd_events = _get_images(d, tag, roi)
 
                 # We assume that all images are for the background
                 # TODO : Perhaps we can loop over the generator
@@ -125,8 +118,7 @@ def get_fastccd_images(light_header, dark_headers=None,
 
         logger.info("Computed dark images in %.3f seconds", ttime.time() - t)
 
-    events = _get_images(light_header, tag, roi,
-                         handler_override=handler_override)
+    events = _get_images(light_header, tag, roi)
 
     # Ok, so lets return a pims pipeline which does the image conversion
 
@@ -184,9 +176,9 @@ def get_images_to_3D(images, dtype=None):
     return im
 
 
-def _get_images(header, tag, roi=None, handler_override=None):
+def _get_images(header, tag, roi=None):
     t = ttime.time()
-    images = get_images(header, tag, handler_override=handler_override)
+    images = header.db.get_images(header, tag)
     t = ttime.time() - t
     logger.info("Took %.3f seconds to read data using get_images", t)
 
@@ -233,12 +225,9 @@ def get_fastccd_timestamps(header, tag='fccd_image'):
         list of arrays of the timestamps
 
     """
-    hover = {tag: AreaDetectorHDF5TimestampHandler}
-    img = [i for i in get_events(header, [tag],
-                                 handler_overrides=hover,
-                                 fill=True)]
-
-    timestamps = [i['data'][tag] for i in img if tag in i['data'].keys()]
+    with header.db.reg.handler_context({'AD_HDF5': AreaDetectorHDF5TimestampHandler}):
+        img = [i for i in get_events(header, [tag], fill=True)]
+        timestamps = [i['data'][tag] for i in img if tag in i['data'].keys()]
 
     return timestamps
 

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -225,7 +225,8 @@ def get_fastccd_timestamps(header, tag='fccd_image'):
         list of arrays of the timestamps
 
     """
-    with header.db.reg.handler_context({'AD_HDF5': AreaDetectorHDF5TimestampHandler}):
+    with header.db.reg.handler_context(
+            {'AD_HDF5': AreaDetectorHDF5TimestampHandler}):
         timestamps = list(header.data(tag))
 
     return timestamps


### PR DESCRIPTION
Tested on production databroker in a CSX notebook:

```python
from csxtools import get_fastccd_images
from databroker import Broker

db = Broker.named('csx')

imgs = get_fastccd_images(db[97934], (db[97931], db[97932], db[96933]))
timestamps = get_fastccd_timestamps(db[97934])
```