### PR TITLE
Make get_fastccd_images() work again

### DIFF
--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -179,7 +179,13 @@ def get_images_to_3D(images, dtype=None):
 def _get_images(header, tag, roi=None):
     t = ttime.time()
     if isinstance(header, (list, tuple)):
-        images = [h.db.get_images(h, tag) for h in header]
+        # assumes all headers are coming from the same db
+        db = header[0].db
+        for h in header:
+            if h.db is not db:
+                raise ValueError("All headers need to come from the same "
+                                 "Broker instance.")
+        images = db.get_images(header, tag)
     else:
         images = header.db.get_images(header, tag)
     t = ttime.time() - t

--- a/csxtools/utils.py
+++ b/csxtools/utils.py
@@ -179,9 +179,9 @@ def get_images_to_3D(images, dtype=None):
 def _get_images(header, tag, roi=None):
     t = ttime.time()
     if isinstance(header, (list, tuple)):
-        images = [img for h in header for img in h.data(tag)]
+        images = [h.db.get_images(h, tag) for h in header]
     else:
-        images = header.data(tag)
+        images = header.db.get_images(header, tag)
     t = ttime.time() - t
     logger.info("Took %.3f seconds to read data using get_images", t)
 


### PR DESCRIPTION
With the current version it is not possible for `get_fastccd_images()` to work as expected: 
```shell
Traceback (most recent call last):
  File "test_csxtools.py", line 37, in <module>
    image = get_single_image(csx_db, 0, 122630)
  File "test_csxtools.py", line 29, in get_single_image
    itr = load_scan_image_itr(db, scan_num, dark8ID, dark2ID, dark1ID)
  File "test_csxtools.py", line 20, in load_scan_image_itr
    silcerator = get_fastccd_images(db[scan_num], dark_headers=dark_headers)
  File "/opt/conda_envs/ptycho_production/lib/python3.7/site-packages/csxtools/utils.py", line 129, in get_fastccd_images
    return _correct_fccd_images(events, bgnd, flat, gain)
  File "/opt/conda_envs/ptycho_production/lib/python3.7/site-packages/slicerator.py", line 599, in process
    return func(obj, *args, **kwargs)
  File "/opt/conda_envs/ptycho_production/lib/python3.7/site-packages/csxtools/utils.py", line 196, in _correct_fccd_images
    image = correct_images(image, bgnd, flat, gain)
  File "/opt/conda_envs/ptycho_production/lib/python3.7/site-packages/csxtools/fastccd/images.py", line 40, in correct_images
    logger.info("Correcting image stack of shape %s", images.shape)
AttributeError: 'generator' object has no attribute 'shape'
```
This happens if running on CSX servers with packages installed from the defaults-2019C3.0 channel, but *not* on JupyerHub srv1 & srv2 (current). 

This PR is needed to get `get_fastccd_images()` working. Also, the ptychography GUI currently relies on this PR (see NSLS-II/ptycho_gui#65). 

As discussed below, all csxtools codes relying on slicerator's `@pipeline` decorator need to be re-worked to be compatible with Databroker's new API.

Closes #64.