### PR TITLE
BLD: fix missing `requirements*.txt` files from the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-requirements.txt
-requirements-extras.txt
+include requirements.txt
+include requirements-extras.txt
 
 include versioneer.py
 include csxtools/_version.py


### PR DESCRIPTION
This PR resolves the malformed instructions to include the `requirements*.txt` files to the source distribution (published on PyPI and can be used by the conda-forge recipes).