### PR TITLE
Use tiled and dask.array.

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,4 +1,3 @@
 databroker
 ipywidgets
 matplotlib
-pims


### PR DESCRIPTION
`get_fastccd_images` and the internal functions that it calls have been using the `pims.pipeline` feature and the deprecated `db.get_images` function. This still _runs_ but it interacts inefficiently with the new databroker internals (tiled). Specifically, it loads the same data multiple times because each lookup of frame reads an entire _chunk_ of adjacent frames, and it does this repeatedly for each frame in the chunk.

I haven't been able to reproduce performance number as poor as what has been reported, but I think the changes in this PR will improve the performance by doing less (wasteful) work.