### PR TITLE
Add pytest-pep8 dependency for test configuration

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ codecov
 coveralls
 flake8
 pytest
+pytest-pep8
 sphinx
 sphinx-bootstrap-theme


### PR DESCRIPTION
This should resolve the "PytestConfigWarning: Unknown config option: pep8ignore" that is showing up in [Unit Tests](https://github.com/NSLS-II-CSX/csxtools/actions/runs/8574126716/job/23500278041).
